### PR TITLE
Update the noobaa nsfs service name

### DIFF
--- a/deployment/deployment.py
+++ b/deployment/deployment.py
@@ -53,7 +53,7 @@ class DeploymentNSFS(Deployment):
         """
         super().__init__()
         self.install_rpm()
-        self.noobaa_nsfs_service = "noobaa"
+        self.noobaa_nsfs_service = "noobaa_nsfs"
         node_rel_path = "node/bin/node"
         self.node_path = os.path.join(config.ENV_DATA["noobaa_core_dir"], node_rel_path)
 
@@ -78,7 +78,9 @@ class DeploymentNSFS(Deployment):
         start_service(name=self.noobaa_nsfs_service, use_sudo=True)
 
         # checks noobaa_nsfs service
-        is_nsfs_running = is_service_running(name=self.noobaa_nsfs_service, use_sudo=True)
+        is_nsfs_running = is_service_running(
+            name=self.noobaa_nsfs_service, use_sudo=True
+        )
         if not is_nsfs_running:
             raise ServiceRunningFailed("noobaa nsfs service is not running")
 


### PR DESCRIPTION
Fixes #10

The new service name is working when we run the following command on the remote machine via:
```
$ sudo systemctl start noobaa_nsfs

$ systemctl status noobaa_nsfs
● noobaa_nsfs.service - The NooBaa nsfs service.
   Loaded: loaded (/usr/lib/systemd/system/noobaa_nsfs.service; disabled; vendor preset: disabled)
   Active: active (running) since Wed 2024-05-01 13:54:29 UTC; 15s ago
```

Further verification is still needed